### PR TITLE
Demo acceptance tests for Kubernetes setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 - [Kafka consumer stats](./kafka-consumer-stats): collect commit rate and offset rate for consumer groups on a Kafka cluster
 - [Gateway API waypoint proxy with Cilium](./gateway-api-cilium): Attempt to create a waypoint proxy setup using Gateway API. Ultimately failed, but useful as a template.
 - [Gateway API GRPC load balancing](./gateway-api-grpc): Use Gateway API and Cilium to get L7 load balancing of GRPC requests.
+- [Acceptance tests for Kuberntes configs](./acceptance-tests): Demonstrating how to use bats to verify that your Kubernetes contracts are upheld.
 - [TiDB benchmarking](./tidb-benchmarks): Set up a three-node TiDB cluster and benchmark it with various methods.
 - [General tools container](./tools-container): builds container image `bittrance/tools` useful for in-cluster debugging
 - [Consul setup](./consul-k8s): sets up a Consul cluster on Kubernetes for testing and development
+- [OIDC Federation with Dex](./oidc-federation): Example OpenID Connect setup, federating with Azure Entra ID.
 - [REST API testing container](./hello-rest): trivial REST API that can artificially delay requests
 
 ## Development setup

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,0 +1,30 @@
+# Demonstration acceptance tests for Kubernetes setup
+
+Over time, a platform team will undertake to provide quite a number of features in their clusters; think external-dns providing hostnames for certain resource attributes, kyverno stopping certain resource configurations, latency guarantees, and so on. As these accumulate, it will be hard to be sure that they all continue to work as designed.
+
+For example, assuming the setup from [Gateway API waypoint proxy with Cilium](./gateway-api-cilium) how do we know that the setup is actually working in all the relevant ways?
+
+This experiment demonstrates how to use [bats](https://bats-core.readthedocs.io/en/stable/) (and some common shell tools) to write acceptance tests for a Kubernetes configuration.
+
+## Setup
+
+Create a Kind cluster according to [Gateway API waypoint proxy with Cilium](./gateway-api-cilium). Add the cert-manager and DNS hack from [OIDC Federation with Dex](./oidc-federation).
+
+Apart from `bats`, these tests assume your path contains `curl`, `host` (the DNS client from Bind) and `kubectl`.
+
+```shell
+bats ./acceptance-tests/tests.bats
+```
+
+The output looks something like this:
+
+```text
+tests.bats
+ ✓ publishes a hostname
+ ✓ redirects to HTTPS
+ ✓ responds on HTTPS
+ ✓ supports HTTPS on HTTP/2 (i.e. ALPN)
+
+4 tests, 0 failures
+```
+

--- a/acceptance-tests/hello-test.yaml
+++ b/acceptance-tests/hello-test.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-test
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: hello-test
+  namespace: hello-test
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+        - kind: Secret
+          group: ""
+          name: hello-test-certificate
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hello-test
+  namespace: hello-test
+spec:
+  secretName: hello-test-certificate
+  isCA: false
+  usages:
+    - server auth
+  dnsNames:
+    - cilium-gateway-hello-test.hello-test.test
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hello-redirect
+  namespace: hello-test
+spec:
+  parentRefs:
+    - name: hello-test
+      port: 80
+      sectionName: http
+  rules:
+    - filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hello-test
+  namespace: hello-test
+spec:
+  parentRefs:
+    - name: hello-test
+      port: 443
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: hello-test
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-test
+  namespace: hello-test
+spec:
+  selector:
+    app: hello-test
+  ports:
+    - name: http
+      port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-test
+  namespace: hello-test
+  labels:
+    app: hello-test
+spec:
+  selector:
+    matchLabels:
+      app: hello-test
+  template:
+    metadata:
+      labels:
+        app: hello-test
+    spec:
+      containers:
+        - name: caddy
+          image: caddy:2.9.1-alpine
+          command:
+            - caddy
+            - respond
+            - --listen
+            - :8080
+            - --body
+            - Hello backend!
+            - --access-log
+          ports:
+            - containerPort: 8080
+

--- a/acceptance-tests/tests.bats
+++ b/acceptance-tests/tests.bats
@@ -1,0 +1,42 @@
+HELLO_HOSTNAME=${HELLO_HOSTNAME:-cilium-gateway-hello-test.hello-test.test}
+KUBECTL=${KUBECTL:-kubectl --context kind-kind}
+
+setup_file() {
+	$KUBECTL apply -f ./acceptance-tests/hello-test.yaml	
+}
+
+teardown_file() {
+	$KUBECTL delete namespace hello-test	
+}
+
+timeout() {
+	local wait_time=$1
+	shift
+	local start=$(date +%s)
+	while ! $* ; do
+		local now=$(date +%s)
+		if [ $((now - start)) -gt $wait_time ] ; then
+			echo "Timeout trying $*" >&2
+			return 1
+		fi
+		echo -n "."
+		sleep 5
+	done
+}
+
+@test "publishes a hostname" {
+	timeout 60 host $HELLO_HOSTNAME
+}
+
+@test "redirects to HTTPS" {
+	local location=$(curl -fs -I -w '%header{location}' -o /dev/null http://$HELLO_HOSTNAME)
+	echo $location | grep -E '^https:'
+}
+
+@test "responds on HTTPS" {
+	curl --insecure -f -o /dev/null https://$HELLO_HOSTNAME
+}
+
+@test "supports HTTPS on HTTP/2 (i.e. ALPN)" {
+	curl --http2 --insecure -f -o /dev/null https://$HELLO_HOSTNAME
+}


### PR DESCRIPTION
This PR adds acceptance tests that demonstrate how a platform team can use bats to verify that they are upholding their contracts towards their users.