### PR TITLE
Simple Kyverno experiment to enforce using release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [General tools container](./tools-container): builds container image `bittrance/tools` useful for in-cluster debugging
 - [Consul setup](./consul-k8s): sets up a Consul cluster on Kubernetes for testing and development
 - [REST API testing container](./hello-rest): trivial REST API that can artificially delay requests
+- [Enforce release versions with Kyverno](./kyverno-enforce-verions): Simple Kyverno rule to ensure deployed workload version numbers follow a certain pattern.
 
 ## Development setup
 

--- a/kyverno-enforce-version/README.md
+++ b/kyverno-enforce-version/README.md
@@ -2,6 +2,10 @@
 
 This experiment strives to demonstrate how to use a Kyverno policy to stop deploys that have non-standard version numbers. The assumption is that builds on master branch are tagged and released with a traditional semver version, while builds from feature branches uses some other versioning scheme.
 
+It can be noted that using Kyverno rules for this is problematic as it will object to individual resources, rather than to a deploy. It is thus better to enforce such constraints in your CD before they are applied to the cluster.
+
+# Setup
+
 Create a standard Kind cluster as per top-level instructions.
 
 ```shell

--- a/kyverno-enforce-version/README.md
+++ b/kyverno-enforce-version/README.md
@@ -1,0 +1,30 @@
+# Enforce release version numbers with Kyverno
+
+This experiment strives to demonstrate how to use a Kyverno policy to stop deploys that have non-standard version numbers. The assumption is that builds on master branch are tagged and released with a traditional semver version, while builds from feature branches uses some other versioning scheme.
+
+Create a standard Kind cluster as per top-level instructions.
+
+```shell
+helm upgrade --install kyverno kyverno/kyverno \
+  --namespace kyverno --create-namespace \
+  --set admissionController.replicas=3 \
+  --set backgroundController.replicas=2 \
+  --set cleanupController.replicas=2 \
+  --set reportsController.replicas=2
+```
+
+Apply the policy:
+
+```shell
+kubectl apply -f ./kyverno-enforce-version/workload-policies.yaml
+```
+
+# Testing the policy:
+
+We can use the canonical [./hello-rest](hello-rest) deployment which has no version and will thus not appease the rule:
+
+```shell
+kubectl create namespace hello-rest
+kubectl label namespaces hello-rest windwards.net/namespace-type=workload
+kubectl --namespace hello-rest apply -f ./hello-rest/hello-rest-deployment.yaml
+```

--- a/kyverno-enforce-version/workload-policies.yaml
+++ b/kyverno-enforce-version/workload-policies.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workload-policies
+  annotations:
+    policies.kyverno.io/title: Policies for workloads
+    policies.kyverno.io/subject: Deployment, StatefulSet, CronJob
+    policies.kyverno.io/description: >-
+      Policies that apply to workloads. Replies apply to namespaces with
+      label windwards.net/namespace-type=workload.
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: enforce-release-version
+      match:
+          resources:
+            namespaceSelector:
+              matchLabels:
+                windwards.net/namespace-type: workload
+            kinds:
+              - Deployment
+              - StatefulSet
+              - CronJob
+            operations:
+              - CREATE
+              - UPDATE
+      validate:
+        cel:
+          variables:
+            - name: version
+              expression: object.metadata.?labels["app.kubernetes.io/version"].orValue('')
+            - name: is_release
+              expression: r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[1-9]+)?$'
+          expressions:
+            - expression: variables.version.matches(variables.is_release)
+              messageExpression: >-
+                'Only release versions can be deployed to this cluster. Regex "' + variables.is_release + '" does not match "' + variables.version + '".'


### PR DESCRIPTION
A more serious approach to this would probably be to have a separate "prod" build environment and check for a signature that it would attach, but this approach works for reminding developers of the prescribed way of working.