### PR TITLE
A resilient Valkey setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Consul setup](./consul-k8s): sets up a Consul cluster on Kubernetes for testing and development
 - [REST API testing container](./hello-rest): trivial REST API that can artificially delay requests
 - [Enforce release versions with Kyverno](./kyverno-enforce-verions): Simple Kyverno rule to ensure deployed workload version numbers follow a certain pattern.
+- [Resilient Valkey setup](./valkey-resiliency): Demonstrate the resiliency of a Sentinel-based Valkey setup, using a k6 load test
 
 ## Development setup
 

--- a/valkey-resiliency/README.md
+++ b/valkey-resiliency/README.md
@@ -1,0 +1,37 @@
+# Resilient Valkey setup
+
+## Creating a Valkey sentinel cluster
+
+Set up a Kind cluster as per top-level instructions. Then install the Sentinel-based Valkey replica set:
+
+```shell
+helm upgrade --install \
+  --namespace valkey-resiliency --create-namespace \
+  --set architecture=replication \
+  --set sentinel.enabled=true \
+  --set sentinel.service.type=LoadBalancer \
+  --set sentinel.primarySet=valkey-resiliency \
+  --set sentinel.downAfterMilliseconds=10000 \
+  --set sentinel.failoverTimeout=30000 \
+  --set networkPolicy.allowExternal=false \
+  valkey \
+  oci://registry-1.docker.io/bitnamicharts/valkey
+```
+
+## Running the tests
+
+```shell
+PASSWORD=$(kubectl --namespace valkey-resiliency get secrets valkey -o jsonpath='{@.data.valkey-password}' | base64 -d)
+kubectl --namespace valkey-resiliency run --image bittrance/tools:0.3.0 valkey-load -- sleep infinity
+kubectl --namespace valkey-resiliency label pods valkey-load valkey-client=true
+kubectl --namespace valkey-resiliency cp ./valkey-resiliency/valkey-load.js valkey-load:/root/
+kubectl --namespace valkey-resiliency exec -it valkey-load -- k6 run -e REDIS_HOSTNAME=valkey -e REDIS_PRIMARYSET=valkey-resiliency -e REDIS_PASSWORD="$PASSWORD" /root/valkey-load.js
+```
+
+While the tests are running, restart Valkey:
+
+```shell
+kubectl --namespace valkey-resiliency rollout restart statefulset valkey-node
+```
+
+Currently, this fails occasionally, probably because the k6 redis client does not purge deleted pods fast enough.

--- a/valkey-resiliency/valkey-load.js
+++ b/valkey-resiliency/valkey-load.js
@@ -1,0 +1,57 @@
+import redis from 'k6/experimental/redis';
+import { check } from "k6";
+
+const host = __ENV.REDIS_HOSTNAME || 'localhost';
+const port = __ENV.REDIS_PORT || 26379;
+const primaryset = __ENV.REDIS_PRIMARYSET;
+const username = __ENV.REDIS_USERNAME;
+const password = __ENV.REDIS_PASSWORD;
+const vus = 40;
+
+export const options = {
+   scenarios: {
+       load: {
+           executor: "constant-arrival-rate",
+           rate: 2,
+           duration: "300s",
+           timeUnit: "1s",
+           preAllocatedVUs: vus,
+       }
+    },
+    summaryTrendStats: ['min', 'med','p(80)', 'p(99)', 'max', 'count'],
+};
+    
+const client = new redis.Client({
+  socket: {
+    host,
+    port,
+  },
+  username,
+  password,
+  masterName: primaryset,
+  sentinelUsername: username,
+  sentinelPassword: password,
+});
+
+const key = `key-${__VU}`;
+let expected = 0;
+
+export async function setup() {
+  for(let n = 0; n < 100000; n++) {
+    await client.set(`dummy-${n}`, 'some large string');
+  }
+  for(let n = 0; n < vus; n++) {
+    await client.del(`key-${n + 1}`);
+  }
+}
+
+export default async function() {
+  await client.incrBy(key, 1);
+  expected += 1;
+  const actual = await client.get(key);
+  check(actual, { "value updated": (v) => v == expected});
+  if (actual != expected) {
+    console.log(`Difference ${expected} != ${actual}`);
+    expected = actual;
+  }
+}


### PR DESCRIPTION
This demonstrates a Valkey configuration which retains its state across rolling restarts.

Currently, this test fails occasionally with i/o timeout errors against pods that have been deleted, but this is likely to be because the k6 redis client is naive.